### PR TITLE
GoとPython以外の部分をコメントアウト

### DIFF
--- a/standalone.yml
+++ b/standalone.yml
@@ -13,18 +13,18 @@
     - nginx
     - mysql
     - golang
-    - perl
-    - php
-    - ruby
+    # - perl
+    # - php
+    # - ruby
     - python
-    - nodejs
+    # - nodejs
     - webapp.mysql
     - webapp.golang
-    - webapp.perl
-    - webapp.php
-    - webapp.ruby
+    # - webapp.perl
+    # - webapp.php
+    # - webapp.ruby
     - webapp.python
-    - webapp.nodejs
+    # - webapp.nodejs
     - webapp.nginx
 
     # for dev
@@ -48,6 +48,6 @@
       loop:
         - nginx.service
         - mysql.service
-        - isucari.golang.service
-        # - shipment.service
-        # - payment.service
+        - isucari.python.service
+        - shipment.service
+        - payment.service


### PR DESCRIPTION
## 概要

- `vagrant up`が遅すぎる問題を改善するために、GoとPython以外のビルド部分をなくした